### PR TITLE
Misc changes for customize_image

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -116,16 +116,18 @@ dpkg --root $IMAGEDIR --force-depends --purge pixel-wallpaper
 chroot $IMAGEDIR apt-get -y install revpi-wallpaper
 chroot $IMAGEDIR apt-get clean
 
-# annoyingly, the postinstall script starts apache2 on fresh installs
-mount -t proc procfs $IMAGEDIR/proc
-sed -r -i -e 's/pidof /pidof -x /' $IMAGEDIR/etc/init.d/apache2
-chroot $IMAGEDIR /etc/init.d/apache2 stop
-umount $IMAGEDIR/proc
+if [ -e "$IMAGEDIR/etc/init.d/apache2" ] ; then
+	# annoyingly, the postinstall script starts apache2 on fresh installs
+	mount -t proc procfs $IMAGEDIR/proc
+	sed -r -i -e 's/pidof /pidof -x /' $IMAGEDIR/etc/init.d/apache2
+	chroot $IMAGEDIR /etc/init.d/apache2 stop
+	umount $IMAGEDIR/proc
 
-# configure apache2
-chroot $IMAGEDIR a2enmod ssl
-sed -r -i -e 's/^(\tOptions .*Indexes.*)/#\1/'		\
-	$IMAGEDIR/etc/apache2/apache2.conf
+	# configure apache2
+	chroot $IMAGEDIR a2enmod ssl
+	sed -r -i -e 's/^(\tOptions .*Indexes.*)/#\1/'		\
+		$IMAGEDIR/etc/apache2/apache2.conf
+fi
 
 # enable ssh daemon by default, disable swap
 chroot $IMAGEDIR systemctl enable ssh


### PR DESCRIPTION
Use losetup for finding loop devices, don't assume lightdm is here and also cleanup a test that fails on my shell (dash)