### PR TITLE
customize_image: fix: delpart: failed to remove partition: Device or …

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -253,6 +253,5 @@ PARTSIZE=$(($PARTSIZE * 8))   # ext4 uses 4k blocks, partitions use 512 bytes
 sfdisk --dump "$LOOPDEVICE" | /bin/sed -r -e "\$!n
 \$s/size=[^,]+/size=$PARTSIZE/" | /sbin/sfdisk "$LOOPDEVICE"
 PARTSTART=$(cat /sys/block/$(basename "$LOOPDEVICE")/$(basename "$LOOPDEVICE"p2)/start)
-truncate -s $((512 * ($PARTSTART + $PARTSIZE))) "$1"
-
 cleanup_losetup
+truncate -s $((512 * ($PARTSTART + $PARTSIZE))) "$1"


### PR DESCRIPTION
…resource busy

Truncating the image might keep the loop device busy even after the
truncate. Just do the cleanup of the loop device before we shrink the
image.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>