### PR TITLE
add the libgcrypt20-dev

### DIFF
--- a/debs-to-download
+++ b/debs-to-download
@@ -26,3 +26,4 @@ node-red-contrib-revpi-nodes
 python3-revpimodio2
 revpipycontrol
 revpipyload
+libgcrypt20-dev


### PR DESCRIPTION
the libgcrypt20-dev is needed for the libtss2-*

Signed-off-by: Zhi Han <z.han@kunbus.com>