### PR TITLE
removing of teamviewer-iot-agent.list not needed

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -225,9 +225,6 @@ chroot $IMAGEDIR /usr/bin/revpi-config enable perf-governor
 # remove package lists, they will be outdated within days
 rm $IMAGEDIR/var/lib/apt/lists/*Packages
 
-# work around duplicate teamviewer apt source
-rm $IMAGEDIR/etc/apt/sources.list.d/teamviewer-iot-agent.list
-
 # install local packages
 if [ "$(/bin/ls $BAKERYDIR/debs-to-install/*.deb 2>/dev/null)" ] ; then
 	mkdir $IMAGEDIR/tmp/debs-to-install


### PR DESCRIPTION
The error of apt install teamviewer-revpi is disappeared now, after
some unknown operation by teamviewer company on repository.teamviewer.com
(maybe updated the version from 2.10.x to 2.11.x, or maybe replace the
package within 2.11.x)

Anyhow, the /etc/apt/sources.list.d/teamviewer-iot-agent.list, which is
contained in version 2.10.18, is not contained from version 2.11.x
anymore. Thus, "rm" makes the script excuted failed.

Signed-off-by: Zhi Han <z.han@kunbus.com>