### PR TITLE
remove the package logiclab from debs to download

### DIFF
--- a/debs-to-download
+++ b/debs-to-download
@@ -19,7 +19,6 @@ newpid
 tcpdump
 gdbserver
 logi-rts
-logiclab
 nodered
 noderedrevpinodes-server
 node-red-contrib-revpi-nodes


### PR DESCRIPTION
By default, the logiclab will not be installed with the image.

Signed-off-by: Zhi Han <z.han@kunbus.com>