### PR TITLE
add the tpm2-tools to the image by default

### DIFF
--- a/debs-to-download
+++ b/debs-to-download
@@ -25,3 +25,4 @@ node-red-contrib-revpi-nodes
 python3-revpimodio2
 revpipycontrol
 revpipyload
+tpm2-tools


### PR DESCRIPTION
There is a TPM Chip on the Flat, so tpm2-tools is needed to use
the TPM function on Flat.

Signed-off-by: Zhi Han <z.han@kunbus.com>