### PR TITLE
add the package revpicommander

### DIFF
--- a/debs-to-download
+++ b/debs-to-download
@@ -25,3 +25,4 @@ node-red-contrib-revpi-nodes
 python3-revpimodio2
 revpipycontrol
 revpipyload
+revpicommander


### PR DESCRIPTION
a new package revpicommander has been provided by Sven Sager described
as "GUI for Revolution Pi to upload programs and do IO-Checks"

Signed-off-by: Zhi Han <z.han@kunbus.com>