### PR TITLE
set default language to en_US.UTF-8

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -157,6 +157,7 @@ sed -i -r -e 's/^(XKBMODEL).*/\1="pc104"/' \
 	-e 's/^(XKBVARIANT).*/\1=""/' \
 	  $IMAGEDIR/etc/default/keyboard
 sed -i -r -e 's/^(LANG).*/\1="en_US.UTF-8"/' $IMAGEDIR/etc/default/locale
+sed -i -r -e 's/^(# en_US.UTF-8 UTF-8)/en_US.UTF-8 UTF-8/' $IMAGEDIR/etc/locale.gen
 install -d -m 755 -o root -g root $IMAGEDIR/etc/revpi
 echo `basename "$1"` > $IMAGEDIR/etc/revpi/image-release
 install -d -m 700 -o 1000 -g 1000 $IMAGEDIR/home/pi/.ssh
@@ -164,6 +165,7 @@ install -d -m 700 -o 1000 -g 1000 $IMAGEDIR/home/pi/.ssh
 # activate settings
 chroot $IMAGEDIR dpkg-reconfigure -fnoninteractive keyboard-configuration
 chroot $IMAGEDIR dpkg-reconfigure -fnoninteractive tzdata
+chroot $IMAGEDIR dpkg-reconfigure -fnoninteractive locales
 
 # automatically bring up eth0 and eth1 again after a USB bus reset
 sed -i -e '6i# allow-hotplug eth0\n# allow-hotplug eth1\n' $IMAGEDIR/etc/network/interfaces


### PR DESCRIPTION
As we have set the default keyboard to us we should also
set the default language to en_US.UTF-8. We need to set
and configure it immediately to avoid setlocale warnings
during the image build.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>