### PR TITLE
install nodered and nodejs via script

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -232,6 +232,16 @@ if [ -e "$IMAGEDIR/etc/init.d/apache2" ] ; then
 		$IMAGEDIR/etc/apache2/apache2.conf
 fi
 
+# install nodejs and nodered with an install script and revpi-nodes from npm repository
+NODEREDSCRIPT="/tmp/update-nodejs-and-nodered.sh"
+/usr/bin/curl -sL \
+	https://raw.githubusercontent.com/node-red/linux-installers/master/deb/update-nodejs-and-nodered\
+	--output $IMAGEDIR/$NODEREDSCRIPT
+/usr/bin/chmod 755 $IMAGEDIR/$NODEREDSCRIPT
+chroot $IMAGEDIR /usr/bin/sudo -u pi $NODEREDSCRIPT --confirm-install --confirm-pi
+/usr/bin/rm $IMAGEDIR/$NODEREDSCRIPT
+chroot $IMAGEDIR /usr/bin/npm install --prefix /home/pi/.node-red node-red-contrib-revpi-nodes
+
 # enable ssh daemon by default, disable swap, disable bluetooth on mini-uart
 chroot $IMAGEDIR systemctl enable ssh
 chroot $IMAGEDIR systemctl disable dphys-swapfile

--- a/debs-to-download
+++ b/debs-to-download
@@ -19,9 +19,7 @@ newpid
 tcpdump
 gdbserver
 logi-rts
-nodered
 noderedrevpinodes-server
-node-red-contrib-revpi-nodes
 python3-revpimodio2
 revpipycontrol
 revpipyload


### PR DESCRIPTION
Since customers prefer installing new modules from npm
repository it could happen that their projects will break if they
install or update nodered-related Debian packages. Therefore we pass on
installing nodejs and nodered from Debian repository and install it
via script. This way there is only one repository (npm) for customers
to take into consideration for new modules or updates.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>