### PR TITLE
Disable autologin on console

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -262,6 +262,12 @@ if [ -e $IMAGEDIR/etc/lightdm/lightdm.conf ] ; then
 		$IMAGEDIR/etc/lightdm/lightdm.conf
 fi
 
+# autologin.conf enables autologin in raspios and raspios-full 
+# but not in raspios-lite
+if [ -e $IMAGEDIR/etc/systemd/system/getty@tty1.service.d/autologin.conf ] ; then
+	rm -f $IMAGEDIR/etc/systemd/system/getty@tty1.service.d/autologin.conf
+fi
+
 # peg cpu at 1200 MHz to maximize spi0 throughput and avoid jitter
 chroot $IMAGEDIR /usr/bin/revpi-config enable perf-governor
 


### PR DESCRIPTION
With images based on raspios and raspios-full autologin is
enabled via autologin configuration, namely autologin.conf.
This is not applicable for our image therefore we have to
disable it here too. Removing file autologin.conf from the
image disables autologin for user pi on console.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>