### PR TITLE
Remove hardcoded path to parted

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -6,8 +6,9 @@ if [ "$#" != 1 ] ; then
 	exit 1
 fi
 
-if [ ! -x /usr/sbin/parted ] ; then
-   echo 1>&1 "Error: /usr/sbin/parted is not executable."
+PARTED="$(which parted)"
+if [ ! -x "$PARTED" ] ; then
+   echo 1>&1 "Error: $PARTED is not executable."
    exit 1
 fi
 
@@ -64,9 +65,9 @@ cleanup() {
 }
 
 trap cleanup ERR SIGINT
-imgsize=$(parted "$1" unit b print | grep -e "\.img" | awk -F ":" '{gsub(/^[ \t]+|[B \t]+$/,"",$2); print $2}')
+imgsize=$($PARTED "$1" unit b print | grep -e "\.img" | awk -F ":" '{gsub(/^[ \t]+|[B \t]+$/,"",$2); print $2}')
 [ "x$imgsize" = "x" ] && echo 1>&1 "Error: Image size not found" && exit 1
-secsize=$(parted "$1" unit b print | grep -e "Sector size" | awk -F "/" '{gsub(/^[ \t]+|[B \t]+$/,"",$3); print $3}')
+secsize=$($PARTED "$1" unit b print | grep -e "Sector size" | awk -F "/" '{gsub(/^[ \t]+|[B \t]+$/,"",$3); print $3}')
 [ "x$secsize" = "x" ] && echo 1>&1 "Error: Sector size not found" && exit 1
 
 # The smallest size of CM3-eMMC is 4 GB  , the available disksize for a system is 3909091328 bytes
@@ -76,7 +77,7 @@ if [ $imgsize -lt 3900000000 ] ; then
    disksize=3909091328
    bcount=$(echo "($disksize-$imgsize)/$secsize" | bc )
    dd if=/dev/zero count=$bcount bs=$secsize >> "$1"
-   parted "$1" resizepart 2 "$((disksize-1))"B
+   $PARTED "$1" resizepart 2 "$((disksize-1))"B
    losetup "$LOOPDEVICE" "$1"
    partprobe "$LOOPDEVICE"
    resize2fs "$LOOPDEVICE"p2
@@ -300,7 +301,7 @@ resize2fs -M "$LOOPDEVICE"p2
 PARTSIZE=$(dumpe2fs -h "$LOOPDEVICE"p2 | egrep "^Block count:" | cut -d" " -f3-)
 PARTSIZE=$((($PARTSIZE+1) * 8))   # ext4 uses 4k blocks, partitions use 512 bytes
 PARTSTART=$(cat /sys/block/$(basename "$LOOPDEVICE")/$(basename "$LOOPDEVICE"p2)/start)
-parted ---pretend-input-tty "$LOOPDEVICE" resizepart 2 "$(($PARTSTART+$PARTSIZE-1))"s yes
+$PARTED ---pretend-input-tty "$LOOPDEVICE" resizepart 2 "$(($PARTSTART+$PARTSIZE-1))"s yes
 truncate -s $((512 * ($PARTSTART + $PARTSIZE))) "$1"
 
 cleanup_losetup


### PR DESCRIPTION
With different Linux distributions we cannot be sure that parted
will always be in the same directory. Therefore we ask the system
where to find parted and use it accordingly.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>