### PR TITLE
Improve error message in case of missing parted

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -7,8 +7,13 @@ if [ "$#" != 1 ] ; then
 fi
 
 PARTED="$(which parted)"
+if [ "x$PARTED" = "x" ] ; then
+	echo 1>&1 "Error: Command parted not found."
+	exit 1
+fi
+
 if [ ! -x "$PARTED" ] ; then
-	echo 1>&1 "Error: $PARTED is not executable."
+	echo 1>&1 "Error: Command $PARTED is not executable."
 	exit 1
 fi
 


### PR DESCRIPTION
Exit with an appropriate error message if parted
is not in $PATH.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>