### PR TITLE
Remove the path for commands rm and chmod

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -253,9 +253,9 @@ NODEREDSCRIPT="/tmp/update-nodejs-and-nodered.sh"
 /usr/bin/curl -sL \
 	https://raw.githubusercontent.com/node-red/linux-installers/master/deb/update-nodejs-and-nodered\
 	--output "$IMAGEDIR/$NODEREDSCRIPT"
-/usr/bin/chmod 755 "$IMAGEDIR/$NODEREDSCRIPT"
+chmod 755 "$IMAGEDIR/$NODEREDSCRIPT"
 chroot "$IMAGEDIR" /usr/bin/sudo -u pi $NODEREDSCRIPT --confirm-install --confirm-pi
-/usr/bin/rm "$IMAGEDIR/$NODEREDSCRIPT"
+rm "$IMAGEDIR/$NODEREDSCRIPT"
 chroot "$IMAGEDIR" /usr/bin/npm install --prefix /home/pi/.node-red node-red-contrib-revpi-nodes
 
 # enable ssh daemon by default, disable swap, disable bluetooth on mini-uart


### PR DESCRIPTION
The command chmod and rm are located in different directories on vary dists.
As it is running on host enviroment, calling it with path is not needed.

Signed-off-by: Zhi Han <z.han@kunbus.com>