### PR TITLE
fix: missing $ on lsof check

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -16,7 +16,7 @@ if [ ! -x "$(which fsck.vfat)" ]; then
 	exit 1
 fi
 
-if [ ! -x "(which lsof)" ]; then
+if [ ! -x "$(which lsof)" ]; then
 	echo 1>&1 "Error: Command lsof not found."
 	exit 1
 fi


### PR DESCRIPTION
The $ signe was missing in the lsof check. This way the check was
usless.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>