### PR TITLE
Add the source URIs to revpi.list

### DIFF
--- a/templates/revpi.list
+++ b/templates/revpi.list
@@ -1,2 +1,4 @@
 deb http://packages.revolutionpi.de/ buster main contrib
+#deb-src http://packages.revolutionpi.de/ buster main contrib
 deb http://packages.revolutionpi.de/ buster-backports main contrib
+#deb-src http://packages.revolutionpi.de/ buster-backports main contrib


### PR DESCRIPTION
As the source packages have been added to the revpi repository, some
commented deb-src instructions in revpi.list make it easier for the
user to get the source packages.

Signed-off-by: Zhi Han <z.han@kunbus.com>