### PR TITLE
Add web browser epiphany to image

### DIFF
--- a/debs-to-download
+++ b/debs-to-download
@@ -23,4 +23,4 @@ python3-revpimodio2
 revpipycontrol
 revpipyload
 revpicommander
-chromium
+epiphany-browser


### PR DESCRIPTION
Our image is missing a web browser. Therefore epiphany browser
has been added since its installed size is the smallest one
amongst all other browsers.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>