### PR TITLE
Add package revpi-bluetooth to debs-to-download

### DIFF
--- a/debs-to-download
+++ b/debs-to-download
@@ -24,3 +24,4 @@ revpipycontrol
 revpipyload
 revpicommander
 epiphany-browser
+revpi-bluetooth


### PR DESCRIPTION
The package revpi-bluetooth is used to setup the bluetooth devices on
booting, so it is needed to be installed by defalut.

Signed-off-by: Zhi Han <z.han@kunbus.de>