### PR TITLE
Remove the deadline ioscheduler from the cmdline

### DIFF
--- a/templates/cmdline.txt
+++ b/templates/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait nosplash plymouth.ignore-serial-consoles
+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 fsck.repair=yes rootwait nosplash plymouth.ignore-serial-consoles


### PR DESCRIPTION
Since some time now the kernel (at least 4.19) uses the deadline
scheduler by default. With kernel 5.10 the elevator= option is ignored
and a warning is printed in the kernel log:

  Kernel parameter elevator= does not have any effect anymore.
  Please use sysfs to set IO scheduler for individual devices.

Remove the elevator=deadline optin from the cmdline.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>