### PR TITLE
Allow releaseinfo changes in order to build older images (REVPI-1901)

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -232,7 +232,7 @@ echo 'APT::Install-Recommends "false";' >> "$IMAGEDIR/etc/apt/apt.conf"
 
 # download and install missing packages
 sed -r -i -e '1ideb http://mirrordirector.raspbian.org/raspbian buster main' "$IMAGEDIR/etc/apt/sources.list"
-chroot "$IMAGEDIR" apt-get update
+chroot "$IMAGEDIR" apt-get update --allow-releaseinfo-change -y
 chroot "$IMAGEDIR" apt-get -y install apt apt-transport-https libapt-inst2.0 libapt-pkg5.0
 sed -r -i -e '1d' "$IMAGEDIR/etc/apt/apt.conf" "$IMAGEDIR/etc/apt/sources.list"
 


### PR DESCRIPTION
If the releaseinfo has changed since the original image was build, the package repo update in customize_image fails. Therefore the first occurence of apt-get update was modified to explicitly allow change of the releaseinfo.

fixes #44

Signed-off-by: Nicolai Buchwitz <nb+github@tipi-net.de>