### PR TITLE
Run parted in script mode

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -327,6 +327,6 @@ resize2fs -M "$LOOPDEVICE"p2
 PARTSIZE=$(dumpe2fs -h "$LOOPDEVICE"p2 | egrep "^Block count:" | cut -d" " -f3-)
 PARTSIZE=$((($PARTSIZE) * 8))   # ext4 uses 4k blocks, partitions use 512 bytes
 PARTSTART=$(cat /sys/block/$(basename "$LOOPDEVICE")/$(basename "$LOOPDEVICE"p2)/start)
-$PARTED "$LOOPDEVICE" resizepart 2 "$(($PARTSTART+$PARTSIZE-1))"s
+$PARTED --script "$LOOPDEVICE" resizepart 2 "$(($PARTSTART+$PARTSIZE-1))"s Yes
 cleanup_losetup
 truncate -s $((512 * ($PARTSTART + $PARTSIZE))) "$1"


### PR DESCRIPTION
Parted prompts for the users OK after warning about possible implication
of resizing a partition. This can be prevented by running parted in
script mode and provide a predefined answer (yes).

fixup of d59701591f1ea8cc7459ec777d334826d496f117

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>