### PR TITLE
REVPI-1928: Use config.txt from template

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -119,19 +119,10 @@ if [ -e /usr/bin/qemu-arm-static ] ; then
 fi
 
 # copy templates
+cp "$BAKERYDIR/templates/config.txt" "$IMAGEDIR/boot"
 cp "$BAKERYDIR/templates/cmdline.txt" "$IMAGEDIR/boot"
 cp "$BAKERYDIR/templates/revpi-aliases.sh" "$IMAGEDIR/etc/profile.d"
 cp "$BAKERYDIR/templates/rsyslog.conf" "$IMAGEDIR/etc"
-
-# force HDMI mode even if no HDMI monitor is detected
-sed -r -i -e 's/#hdmi_force_hotplug=1/hdmi_force_hotplug=1/' \
-	  -e 's/#hdmi_drive=2/hdmi_drive=2/' \
-	  "$CONFIGTXT"
-
-# Add dwc2 overlay for CM4(S)
-MF_DWC2="\[cm4s\]"
-grep -q  "$MF_DWC2" "$CONFIGTXT" || sed -i "/^\[all\]/i $MF_DWC2\n" "$CONFIGTXT"
-sed -r -i -e "/$MF_DWC2/ a dtoverlay=dwc2,dr_mode=host"  "$CONFIGTXT"
 
 # limit disk space occupied by logs
 ln -s ../cron.daily/logrotate "$IMAGEDIR/etc/cron.hourly"

--- a/templates/config.txt
+++ b/templates/config.txt
@@ -1,0 +1,63 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment this if your display has a black border of unused pixels visible
+# and your display can output without overscan
+#disable_overscan=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+[cm4s]
+dtoverlay=dwc2,dr_mode=host
+#dtoverlay=vc4-kms-v3d
+#max_framebuffers=2
+


### PR DESCRIPTION
Since we rely on various modifications of the /boot/config.txt, it is
safer to use a template instead of the one provided by the image. All
further modification have to be applied to templates/config.txt

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>