### PR TITLE
Remove /home/pi/Bookshelf [REVPI-1941]

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -161,6 +161,11 @@ chown -R 1000:1000 "$IMAGEDIR/home/pi/demo"
 chmod -R a+rX "$IMAGEDIR/home/pi/demo"
 rm -r $PICONTROLDIR
 
+# remove bookshelf if present
+if [[ -d $IMAGEDIR/home/pi/Bookshelf ]]; then
+    rm -r $IMAGEDIR/home/pi/Bookshelf
+fi
+
 # customize settings
 echo Europe/Berlin > "$IMAGEDIR/etc/timezone"
 rm "$IMAGEDIR/etc/localtime"


### PR DESCRIPTION
Remove unused folder /home/pi/Bookshelf (if present) in order to save additional 35 MB in our image.

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>