### PR TITLE
customize_image.sh:fix e2fsck in noninteractive env[REVPI-2335]-master

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -102,7 +102,7 @@ if [ $imgsize -lt 3900000000 ] ; then
 	losetup "$LOOPDEVICE" "$1"
 	partprobe "$LOOPDEVICE"
 	resize2fs "$LOOPDEVICE"p2
-	e2fsck -f "$LOOPDEVICE"p2
+	e2fsck -p -f "$LOOPDEVICE"p2
 	sync
 	losetup -D
 fi


### PR DESCRIPTION
The e2fsck get failed when it is executed in noninteractive
environment, the option -p can be used to avoid it.

Signed-off-by: Zhi Han <z.han@kunbus.com>