### PR TITLE
Revert "customize_image.sh: Remove model filter [cm4s]" [REVPI-2355]

### DIFF
--- a/templates/config.txt
+++ b/templates/config.txt
@@ -60,4 +60,8 @@ dtparam=audio=on
 #dtoverlay=vc4-kms-v3d
 #max_framebuffers=2
 
+[pi4]
+[cm4s]
+dtoverlay=dwc2,dr_mode=host
+
 [all]


### PR DESCRIPTION
This reverts commit 4a3c0203c7b2a5e821449068f54954d013bd6930.

We need to enable the dwc2 on all CM4S devices. Other wise no USB driver
is active without our overlays loaded. Our overlays are only loaded
after the factory reset. And without a working USB no access to the
device is possible.