### PR TITLE
customize_image.sh: Answer yes to parted

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -323,6 +323,6 @@ resize2fs -M "$LOOPDEVICE"p2
 PARTSIZE=$(dumpe2fs -h "$LOOPDEVICE"p2 | egrep "^Block count:" | cut -d" " -f3-)
 PARTSIZE=$((($PARTSIZE) * 8))   # ext4 uses 4k blocks, partitions use 512 bytes
 PARTSTART=$(cat /sys/block/$(basename "$LOOPDEVICE")/$(basename "$LOOPDEVICE"p2)/start)
-$PARTED "$LOOPDEVICE" resizepart 2 "$(($PARTSTART+$PARTSIZE-1))"s
+echo Yes | $PARTED ---pretend-input-tty "$LOOPDEVICE" resizepart 2 "$(($PARTSTART+$PARTSIZE-1))"s
 cleanup_losetup
 truncate -s $((512 * ($PARTSTART + $PARTSIZE))) "$1"


### PR DESCRIPTION
Take reference of t7000-scripting.sh in parted test cases, the
option ---pretend-input-tty can be used in this way to do the
interactive. https://git.savannah.gnu.org/cgit/parted.git/tree/tests/t7000-scripting.sh?h=v3.2#n62

Although this option is undocumented, it is contained in the
version from 3.2 (buster) till at least v3.5, https://git.savannah.gnu.org/cgit/parted.git/tree/parted/parted.c?h=v3.5#n132
which is adopted by bookworm. https://packages.debian.org/bookworm/parted

Signed-off-by: Zhi Han <z.han@kunbus.com>