### PR TITLE
Remove check for program call parameter count [REVPI-2413]

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -7,11 +7,6 @@ usage () {
   -h, --help		Print the usage page'
 }
 
-if [ "$#" != 1 ] ; then
-	usage;
-	exit 1
-fi
-
 if [ ! -x "$(which curl)" ]; then
 	echo 1>&1 "Error: Command curl not found."
 	exit 1


### PR DESCRIPTION
With using getopt for program parameter evaluation there is no further
need to check the count of the program parameters given by a user during
script call/execution. The check, that was implemented, failed as soon
as the minimize option was used.

Signed-off-by: Frank Erdrich <f.erdrich@kunbus.com>