### PR TITLE
Remove wiringpi [REVPI-2492]

### DIFF
--- a/debs-to-remove
+++ b/debs-to-remove
@@ -1,6 +1,9 @@
 # VLC media player
 vlc
 
+# Remove wiringpi
+wiringpi
+
 # Remove all web browsers except epiphany
 chromium
 chromium-browser


### PR DESCRIPTION
Wiringpi is officially deprecated by the author and should not be used anymore on RevPi devices. It is already removed in the official bullseye images from the Raspberry Pi foundation, but still present on buster.