### PR TITLE
use UTC as default to avoid DST changes

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -193,7 +193,7 @@ if [[ -d $IMAGEDIR/home/pi/Bookshelf ]]; then
 fi
 
 # customize settings
-echo Europe/Berlin > "$IMAGEDIR/etc/timezone"
+echo Etc/UTC > "$IMAGEDIR/etc/timezone"
 rm "$IMAGEDIR/etc/localtime"
 echo RevPi > "$IMAGEDIR/etc/hostname"
 sed -i -e 's/raspberrypi/RevPi/g' "$IMAGEDIR/etc/hosts"


### PR DESCRIPTION
In order to reduce the impact of DST changes, I think UTC is a better default timezone than a German one.