### PR TITLE
Compability with recent Raspberry Pi Images

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -312,8 +312,7 @@ chroot "$IMAGEDIR" systemctl disable revpipyload
 
 # boot to console by default, disable autologin
 chroot "$IMAGEDIR" systemctl set-default multi-user.target
-ln -fs /lib/systemd/system/getty@.service		\
-	"$IMAGEDIR/etc/systemd/system/getty.target.wants/getty@tty1.service"
+chroot "$IMAGEDIR" systemctl enable getty@tty1.service
 if [ -e "$IMAGEDIR/etc/lightdm/lightdm.conf" ] ; then
 	sed -r -i -e "s/^autologin-user=/#autologin-user=/"	\
 		"$IMAGEDIR/etc/lightdm/lightdm.conf"

--- a/customize_image.sh
+++ b/customize_image.sh
@@ -175,7 +175,7 @@ cp "$BAKERYDIR/templates/revpi.list" "$IMAGEDIR/etc/apt/sources.list.d"
 # from ld.so:
 #   ERROR: ld.so: object '/usr/lib/arm-linux-gnueabihf/libarmmem-${PLATFORM}.so'
 #   from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
-mv "$IMAGEDIR/etc/ld.so.preload" "$IMAGEDIR/etc/ld.so.preload.bak"
+[[ -f "$IMAGEDIR/etc/ld.so.preload" ]] && mv "$IMAGEDIR/etc/ld.so.preload" "$IMAGEDIR/etc/ld.so.preload.bak"
 
 # copy piTest source code
 PICONTROLDIR=`mktemp -d -p /tmp piControl.XXXXXXXX`
@@ -343,7 +343,7 @@ find "$IMAGEDIR/var/log" -type f -delete
 find "$IMAGEDIR/etc/ssh" -name "ssh_host_*_key*" -delete
 
 # restore ld.so.preload
-mv "$IMAGEDIR/etc/ld.so.preload.bak" "$IMAGEDIR/etc/ld.so.preload"
+[[ -f "$IMAGEDIR/etc/ld.so.preload.bak" ]] && mv "$IMAGEDIR/etc/ld.so.preload.bak" "$IMAGEDIR/etc/ld.so.preload"
 
 cleanup_umount
 

--- a/customize_image.sh
+++ b/customize_image.sh
@@ -325,6 +325,14 @@ fi
 # peg cpu at 1200 MHz to maximize spi0 throughput and avoid jitter
 chroot "$IMAGEDIR" /usr/bin/revpi-config enable perf-governor
 
+# Since Raspberry Pi OS Bullseye the default user pi will only be used for the first
+# boot and then replaced by a username which has to be defined in the first boot wizzard.
+# Therefore we need to disable the userconfig and set the password to the previous default `raspberry`
+if [[ ! $(grep -q -E '^pi:\*' "$IMAGEDIR/etc/shadow" ]]; then
+	echo 'pi:$6$5usxnY6BwGl83hNQ$0GVkJryIjIXghLatO.wPACaDpg5h.wuZLxZr/Cw1Wx5gNZBADY6lbCRTI2J4TGR6/OdeW1trX3/PjmZtSjZhd/' | chroot "$IMAGEDIR" /usr/sbin/chpasswd -e
+	chroot "$IMAGEDIR" systemctl disable userconfig
+fi
+
 # remove package lists, they will be outdated within days
 rm "$IMAGEDIR/var/lib/apt/lists/"*Packages
 

--- a/customize_image.sh
+++ b/customize_image.sh
@@ -253,10 +253,8 @@ rm -rf "$IMAGEDIR/home/pi/MagPi"
 echo 'APT::Install-Recommends "false";' >> "$IMAGEDIR/etc/apt/apt.conf"
 
 # download and install missing packages
-sed -r -i -e '1ideb http://mirrordirector.raspbian.org/raspbian buster main' "$IMAGEDIR/etc/apt/sources.list"
 chroot "$IMAGEDIR" apt-get update --allow-releaseinfo-change -y
 chroot "$IMAGEDIR" apt-get -y install apt apt-transport-https libapt-inst2.0 libapt-pkg5.0
-sed -r -i -e '1d' "$IMAGEDIR/etc/apt/apt.conf" "$IMAGEDIR/etc/apt/sources.list"
 
 chroot "$IMAGEDIR" apt-get -y install `egrep -v '^#' "$BAKERYDIR/min-debs-to-download"`
 if [ "$MINIMG" != "1" ]; then

--- a/customize_image.sh
+++ b/customize_image.sh
@@ -254,7 +254,6 @@ echo 'APT::Install-Recommends "false";' >> "$IMAGEDIR/etc/apt/apt.conf"
 
 # download and install missing packages
 chroot "$IMAGEDIR" apt-get update --allow-releaseinfo-change -y
-chroot "$IMAGEDIR" apt-get -y install apt apt-transport-https libapt-inst2.0 libapt-pkg5.0
 
 chroot "$IMAGEDIR" apt-get -y install `egrep -v '^#' "$BAKERYDIR/min-debs-to-download"`
 if [ "$MINIMG" != "1" ]; then

--- a/debs-to-remove
+++ b/debs-to-remove
@@ -47,6 +47,7 @@ gcc-7-base
 
 # Remove header files not required by any other package
 libfreetype6-dev
+libfreetype-dev
 libpng-dev
 
 # Remove all fonts not required by any other package

--- a/min-debs-to-download
+++ b/min-debs-to-download
@@ -9,7 +9,6 @@ pitest
 pimodbus-master
 pimodbus-slave
 can-utils
-python-can
 python3-can
 libsocketcan-dev
 cpufrequtils


### PR DESCRIPTION
This PR is intended to ensure compatibility of Imagebakery with the latest Raspberry Pi Bullseye image. It also removes legacy code that is no longer needed under the condition that the functionality with Buster is also ensured. If it will make sense, I'm happy to split the comments in different PRs. 

@l1k I only referenced you as a reviewer for historical knowledge about some of the legacy parts :eyes:  (esp. 4da1ba8e2f985a68ef6398d66f85556bf70a8889 and f0146b0cf64880848da660606dfc2d920990ec2f)