### PR TITLE
install dt-blob.bin from revpi-dt-blob.dtbo

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -341,6 +341,9 @@ find "$IMAGEDIR/etc/ssh" -name "ssh_host_*_key*" -delete
 # restore ld.so.preload
 [[ -f "$IMAGEDIR/etc/ld.so.preload.bak" ]] && mv "$IMAGEDIR/etc/ld.so.preload.bak" "$IMAGEDIR/etc/ld.so.preload"
 
+# after package raspberrypi-kernel installed, install revpi-dt-blob.dtbo as default dt-blob
+install -T "$IMAGEDIR/boot/overlays/revpi-dt-blob.dtbo" "$IMAGEDIR/boot/dt-blob.bin"
+
 cleanup_umount
 
 fsck.vfat -a "$LOOPDEVICE"p1


### PR DESCRIPTION
For CM3 and CM4S the pin configuration of HAT EEPROM is contained in revpi-dt-blob-overlay.dts, and in generated revpi-dt-blob.dtbo. This should be used for the first booting with HAT EEPROM to recongnize it well.

The dt-blob.bin is the right file for this purpose, as it will be loaded by vc core and get applied for the kernel.

Signed-off-by: Zhi Han <z.han@kunbus.com>