### PR TITLE
Add support for Raspberry Pi OS Bullseye [REVPI-2640]

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -324,6 +324,14 @@ fi
 # peg cpu at 1200 MHz to maximize spi0 throughput and avoid jitter
 chroot "$IMAGEDIR" /usr/bin/revpi-config enable perf-governor
 
+# Since Raspberry Pi OS Bullseye the default user pi will only be used for the first
+# boot and then replaced by a username which has to be defined in the first boot wizard.
+# Therefore we need to disable the userconfig and set the password to the previous default `raspberry`
+if [[ ! $(grep -q -E '^pi:\*' "$IMAGEDIR/etc/shadow" ]]; then
+	echo 'pi:raspberry' | chroot "$IMAGEDIR" /usr/sbin/chpasswd
+	chroot "$IMAGEDIR" systemctl disable userconfig
+fi
+
 # remove package lists, they will be outdated within days
 rm "$IMAGEDIR/var/lib/apt/lists/"*Packages
 

--- a/customize_image.sh
+++ b/customize_image.sh
@@ -193,7 +193,7 @@ if [[ -d $IMAGEDIR/home/pi/Bookshelf ]]; then
 fi
 
 # customize settings
-echo Europe/Berlin > "$IMAGEDIR/etc/timezone"
+echo UTC > "$IMAGEDIR/etc/timezone"
 rm "$IMAGEDIR/etc/localtime"
 echo RevPi > "$IMAGEDIR/etc/hostname"
 sed -i -e 's/raspberrypi/RevPi/g' "$IMAGEDIR/etc/hosts"

--- a/debs-to-remove
+++ b/debs-to-remove
@@ -47,6 +47,7 @@ gcc-7-base
 
 # Remove header files not required by any other package
 libfreetype6-dev
+libfreetype-dev
 libpng-dev
 
 # Remove all fonts not required by any other package

--- a/min-debs-to-download
+++ b/min-debs-to-download
@@ -9,7 +9,6 @@ pitest
 pimodbus-master
 pimodbus-slave
 can-utils
-python-can
 python3-can
 libsocketcan-dev
 cpufrequtils


### PR DESCRIPTION
This PR adds patches in order to support Raspberry Pi OS Bullseye:

- Add default user `pi` to the image as lots of software in our image relies on this
- Remove Python2 packages (EOL since 2020-01-01)
- Update package names on our absent list
- Switch to `UTC` as default timezone (see #74 and internal discussion)

NOTE: This PR doesn't target the master branch, but the `bullseye` branch