### PR TITLE
[REVPI-2581] Adjust the install debs script to generate up to date image

### DIFF
--- a/install_debs_into_image.sh
+++ b/install_debs_into_image.sh
@@ -165,6 +165,16 @@ if [ "$(/bin/ls "$BAKERYDIR/debs-to-install/"*.deb 2>/dev/null)" ] ; then
 	chroot "$IMAGEDIR" sh -c "dpkg -i /tmp/debs-to-install/*.deb"
 fi
 
+# install local files
+LIST_INS="$BAKERYDIR/files-to-install/list.ins"
+if [ -f $LIST_INS  ] ; then
+        while IFS= read -r line
+        do
+                echo "install file:$line"
+                install -T "$BAKERYDIR/files-to-install/$(basename $line)" "$IMAGEDIR/$line"
+        done < "$LIST_INS"
+fi
+
 # remove logs and ssh host keys
 find "$IMAGEDIR/var/log" -type f -delete
 find "$IMAGEDIR/etc/ssh" -name "ssh_host_*_key*" -delete

--- a/install_debs_into_image.sh
+++ b/install_debs_into_image.sh
@@ -172,6 +172,9 @@ find "$IMAGEDIR/etc/ssh" -name "ssh_host_*_key*" -delete
 # restore ld.so.preload
 mv "$IMAGEDIR/etc/ld.so.preload.bak" "$IMAGEDIR/etc/ld.so.preload"
 
+# after package raspberrypi-kernel installed, install revpi-dt-blob.dtbo as default dt-blob
+install -T "$IMAGEDIR/boot/overlays/revpi-dt-blob.dtbo" "$IMAGEDIR/boot/dt-blob.bin"
+
 cleanup_umount
 
 fsck.vfat -a "$LOOPDEVICE"p1

--- a/install_debs_into_image.sh
+++ b/install_debs_into_image.sh
@@ -66,6 +66,7 @@ LOOPDEVICE=$(losetup -f)
 CONFIGTXT="$IMAGEDIR/boot/config.txt"
 
 cleanup_umount() {
+	sync
 	if [ -e "$IMAGEDIR" ] ; then
 		lsof -t "$IMAGEDIR" | xargs --no-run-if-empty kill
 	fi


### PR DESCRIPTION
1. for "minimized" image
2. for dt-blob.bin
3. add sync before cleanup mount
4. add ability of add files