### PR TITLE
Reduce dependencies and improve update duration

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -207,6 +207,7 @@ sed -i -r -e 's/^(XKBMODEL).*/\1="pc104"/' \
 	  "$IMAGEDIR/etc/default/keyboard"
 sed -i -r -e 's/^(LANG).*/\1="en_US.UTF-8"/' "$IMAGEDIR/etc/default/locale"
 sed -i -r -e 's/^(# en_US.UTF-8 UTF-8)/en_US.UTF-8 UTF-8/' "$IMAGEDIR/etc/locale.gen"
+sed -i -r -e 's/^(en_GB.UTF-8 UTF-8)/# en_GB.UTF-8 UTF-8/' "$IMAGEDIR/etc/locale.gen"
 install -d -m 755 -o root -g root "$IMAGEDIR/etc/revpi"
 echo `basename "$1"` > "$IMAGEDIR/etc/revpi/image-release"
 install -d -m 700 -o 1000 -g 1000 "$IMAGEDIR/home/pi/.ssh"

--- a/debs-to-download
+++ b/debs-to-download
@@ -1,3 +1,4 @@
 logi-rts
+revpicommander
 noderedrevpinodes-server
 epiphany-browser

--- a/min-debs-to-download
+++ b/min-debs-to-download
@@ -18,9 +18,7 @@ newpid
 tcpdump
 gdbserver
 python3-revpimodio2
-revpipycontrol
 revpipyload
-revpicommander
 revpi-bluetooth
 python3-libgpiod
 python3-yaml


### PR DESCRIPTION
First commit: install revpicommander and revpipycontrol only in full image as they depend on things like TK and QT5 which result lots of unnecessary dependencies in our lite image.

Second commit: Reduce time (approx 35 seconds on CM3) needed for locale update (eg. after package update) by using only en_US in our image