### PR TITLE
Make collect sources usable (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ If you would like to modify an existing image by only installing some packages (
 
 ### Collect sources on a physical medium for GPL compliance
 
-(requires root and Internet connectivity):
+The script `collect_sources.sh` can be used to collect the sources of the packages shipped with our official image. The official images can be found on our [download page](https://revolutionpi.de/tutorials/downloads/#revpiimages). 
 
-`collect_sources.sh <raspbian-image> /media/usbstick`
+> **Note:** This step requires root access and Internet connectivity.
+
+#### Usage
+
+```
+./collect_sources.sh <revpi-image> /media/usbstick
+
+# eg. ./collect_sources.sh 2022-07-28-revpi-buster-lite.img /media/usbstick
+```

--- a/collect_sources.sh
+++ b/collect_sources.sh
@@ -72,7 +72,7 @@ dpkg-query --admindir $APTROOT/var/lib/dpkg -W		\
 knl_version=$(dpkg-query --admindir $APTROOT/var/lib/dpkg -W \
 	-f='${source:Version}' raspberrypi-kernel || true)
 knl_tag="raspberrypi-kernel_$knl_version"
-knl_tag=$(sed 's/:/%25/g' <<< "$knl_tag")
+knl_tag=${knl_tag//\:/%25}
 wget -O "linux-$knl_version.tar.gz" "https://github.com/RevolutionPi/linux/archive/refs/tags/$knl_tag.tar.gz"
 wget -O "piControl-$knl_version.tar.gz" "https://github.com/RevolutionPi/piControl/archive/refs/tags/$knl_tag.tar.gz"
 wget -O IODeviceExample.tar.gz https://github.com/RevolutionPi/IODeviceExample/archive/master.tar.gz

--- a/collect_sources.sh
+++ b/collect_sources.sh
@@ -84,6 +84,8 @@ dpkg-query --admindir $APTROOT/var/lib/dpkg -W \
 knl_version=$(dpkg-query --admindir $APTROOT/var/lib/dpkg -W \
 	-f='${source:Version}' raspberrypi-kernel || true)
 knl_tag="raspberrypi-kernel_$knl_version"
+# GIT tags cannot contain the ':' character, therefore we substitute it with '%' (url-encoded).
+# see https://dep-team.pages.debian.net/deps/dep14/ (Version mangling) for more details
 knl_tag=${knl_tag//\:/%25}
 wget -O "linux-$knl_version.tar.gz" "https://github.com/RevolutionPi/linux/archive/refs/tags/$knl_tag.tar.gz"
 wget -O "piControl-$knl_version.tar.gz" "https://github.com/RevolutionPi/piControl/archive/refs/tags/$knl_tag.tar.gz"

--- a/collect_sources.sh
+++ b/collect_sources.sh
@@ -66,7 +66,7 @@ cd "$2"
 dpkg-query --admindir $APTROOT/var/lib/dpkg -W		\
 	-f='${source:Package}=${source:Version}\n'	\
 	| grep -E -v "^($EXCLUDE)=" | sort | uniq		\
-	| while read package ; do fetch_deb_src "$package" ; done
+	| while read -r package ; do fetch_deb_src "$package" ; done
 
 # fetch RevolutionPi sources
 knl_version=$(dpkg-query --admindir $APTROOT/var/lib/dpkg -W \

--- a/collect_sources.sh
+++ b/collect_sources.sh
@@ -3,7 +3,7 @@
 # burn them on a physical medium for GPL compliance
 
 if [ "$#" != 2 ] ; then
-	echo 1>&1 "Usage: `basename $0` <image> <destination>"
+	echo 1>&1 "Usage: $(basename $0) <image> <destination>"
 	exit 1
 fi
 

--- a/collect_sources.sh
+++ b/collect_sources.sh
@@ -65,7 +65,7 @@ EXCLUDE+='|raspberrypi-firmware|picontrol|revpi-firmware'
 cd "$2"
 dpkg-query --admindir $APTROOT/var/lib/dpkg -W		\
 	-f='${source:Package}=${source:Version}\n'	\
-	| egrep -v "^($EXCLUDE)=" | sort | uniq		\
+	| grep -E -v "^($EXCLUDE)=" | sort | uniq		\
 	| while read package ; do fetch_deb_src "$package" ; done
 
 # fetch RevolutionPi sources

--- a/collect_sources.sh
+++ b/collect_sources.sh
@@ -3,7 +3,7 @@
 # burn them on a physical medium for GPL compliance
 
 if [ "$#" != 2 ] ; then
-	echo 1>&1 "Usage: $(basename $0) <image> <destination>"
+	echo 1>&1 "Usage: $(basename "$0") <image> <destination>"
 	exit 1
 fi
 
@@ -46,7 +46,7 @@ fetch_deb_src() {
 	apt-get -o RootDir=$APTROOT -o APT::Sandbox::User="" --download-only \
 		source "$1" ||
 	apt-get -o RootDir=$APTROOT -o APT::Sandbox::User="" --download-only \
-		source "$(echo $1 | cut -d= -f1)"
+		source "$(echo "$1" | cut -d= -f1)"
 }
 
 # exclude binary-only Raspbian packages

--- a/collect_sources.sh
+++ b/collect_sources.sh
@@ -79,7 +79,7 @@ wget -O IODeviceExample.tar.gz https://github.com/RevolutionPi/IODeviceExample/a
 wget -O python3-revpimodio2.tar.gz https://github.com/naruxde/revpimodio2/archive/master.tar.gz
 
 # take node modules sources from root directory of npm
-tar -czvf node_modules.tar.gz "$IMAGEDIR/usr/lib/node_modules"
+test -d "$IMAGEDIR/usr/lib/node_modules" && tar -czvf node_modules.tar.gz "$IMAGEDIR/usr/lib/node_modules"
 
 # clean up
 rm -r $APTROOT


### PR DESCRIPTION
This PR implements the following fixes / improvement:

- Support lite image (no NodeRed and therefore no nodejs modules)
- Improve documentation and make clear that the RevPi Image must be used and not the Raspberry Pi Image
- Fix several shell-check complaints and formatting issues