### PR TITLE
Use hosts nameservers [REVPI-2887]

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -74,6 +74,9 @@ cleanup_umount() {
 	if [ -e "$IMAGEDIR" ] ; then
 		lsof -t "$IMAGEDIR" | xargs --no-run-if-empty kill
 	fi
+	if [ -e "$IMAGEDIR/etc/resolv.conf" ] ; then
+		umount "$IMAGEDIR/etc/resolv.conf"
+	fi
 	if [ -e "$IMAGEDIR/usr/bin/qemu-arm-static" ] ; then
 		rm -f "$IMAGEDIR/usr/bin/qemu-arm-static"
 	fi
@@ -138,6 +141,7 @@ losetup "$LOOPDEVICE" "$1"
 partprobe "$LOOPDEVICE"
 mount "$LOOPDEVICE"p2 "$IMAGEDIR"
 mount "$LOOPDEVICE"p1 "$IMAGEDIR/boot"
+mount --bind /etc/resolv.conf "$IMAGEDIR/etc/resolv.conf"
 
 # see https://wiki.debian.org/QemuUserEmulation
 if [ -e /usr/bin/qemu-arm-static ] ; then


### PR DESCRIPTION
Currently the chroot environment relies on nameserver settings in the target's filesystem. This could be problematic in environments where specific nameserver are required (company network, vpn, etc.).

Fix this issue by bind-mounting the hosts resolv.conf.

Suggested-by: Sven Sager <s.sager@kunbus.com>
Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>