### PR TITLE
Claim extra space in the image for EOL tests

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -347,7 +347,12 @@ fsck.ext4 -f -p "$LOOPDEVICE"p2
 sleep 2
 
 # shrink image to speed up flashing
-resize2fs -M "$LOOPDEVICE"p2
+# HACK: Get minimum image size, add some blocks for extra space and shrink image to this size
+# (will be removed when we have a first boot service)
+SHRINKED_SIZE=$(resize2fs -P "$LOOPDEVICE"p2 | cut -f 2 -d :)
+SHRINKED_SIZE=$((SHRINKED_SIZE + 20000))
+resize2fs "$LOOPDEVICE"p2 "$SHRINKED_SIZE"
+
 PARTSIZE=$(dumpe2fs -h "$LOOPDEVICE"p2 | egrep "^Block count:" | cut -d" " -f3-)
 PARTSIZE=$((($PARTSIZE) * 8))   # ext4 uses 4k blocks, partitions use 512 bytes
 PARTSTART=$(cat /sys/block/$(basename "$LOOPDEVICE")/$(basename "$LOOPDEVICE"p2)/start)


### PR DESCRIPTION
For the EOL test it is required to have some free space in the image in order to copy files for provisioning. Previously, this was accomplished through the use of magic (probably due to alignment or other implicit fs defaults).

This won't work with the latest RPi Buster image.

Fix this by explicitly claiming additional free space when shrinking the image.

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>