### PR TITLE
Optional output image name [REVPI-2886]

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ sudo apt-get install qemu-user-static binfmt-support
 
 In order to build an image with only software that is necessary for basic operation (eg. Pictory and other RevPi tools), you have to call the customization script with the `--minimize` option. This option is used to build our official lite image (based on the foundations lite image).
 
-`customize_image.sh --minimize <raspbian-image>`
+`customize_image.sh --minimize <raspberrypi-image> [output-image]`
 
 For an image with all additional components (like NodeRed, logi-rts and Teamviewer), you must call the customization script without any options:
 
-`customize_image.sh <raspbian-image>`
+`customize_image.sh <raspberrypi-image> [output-image]`
 
 
 ### Install debian packages into Revolution Pi Image


### PR DESCRIPTION
Add an optional parameter for the name of the output image. If this name is given, the imagebakery will copy the source image to it and apply all modifications. Otherwise, a warning message is displayed, which the user must acknowledge before the program can continue. The modifications will be applied in-place as before in the aforementioned case.