### PR TITLE
Use the external WLAN antenna on CM4 devices

### DIFF
--- a/templates/config.txt
+++ b/templates/config.txt
@@ -63,5 +63,7 @@ dtparam=audio=on
 [pi4]
 [cm4s]
 dtoverlay=dwc2,dr_mode=host
+[cm4]
+dtparam=ant2
 
 [all]


### PR DESCRIPTION
Some CM4 variantes have WLAN and bluetooth support. If a RevPi has a CM4 an external antenna (SMA) connector is provided. Our assumption is, that a most user will use an external antenna. As most devices will be placed inside a closed, many times, metal casing.