### PR TITLE
Add a fake piSerial script for webstatus

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -373,6 +373,10 @@ cp "$BAKERYDIR/templates/50-revpi.rules" "$IMAGEDIR/lib/udev/rules.d"
 # piCtory a4b5761fe3499fddfa76dedd9b45d7ef7485854e
 cp -R "$BAKERYDIR/templates/pictory" "$IMAGEDIR/var/www/revpi/pictory/"
 
+# Install fake version of piSerial script
+cp "$BAKERYDIR/templates/piSerial" "$IMAGEDIR/usr/sbin/"
+chmod +x "$IMAGEDIR/usr/sbin/piSerial"
+
 # # # # # REVPI-3106 END
 
 cleanup_umount

--- a/templates/piSerial
+++ b/templates/piSerial
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright: 2023 KUNBUS GmbH
+#
+
+function usage {
+    echo 'usage: piSerial [-p|-s|-v]
+
+  -p print the generated password
+  -s print the serial number
+  -v show revpi-piserial version and exit
+If no option is specified the serial number and password are printed.'
+}
+
+while getopts ":spv" OPTION ; do
+    case ${OPTION} in
+    s)
+        echo 0123456789ABCDEF
+        ;;
+    p)
+        echo revpi4
+        ;;
+    v)
+        echo PiSerial f.a.k.e
+        ;;
+    *)
+        usage
+        exit 1;
+        ;;
+    esac
+done


### PR DESCRIPTION
We do not yet have a compatible version of revpi-serial. Until completion, we use a fake version.