### PR TITLE
fix: Accept parameter -f / --force

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -46,7 +46,7 @@ MINIMG=0
 FORCE=0
 
 # get the options
-if ! MYOPTS=$(getopt -o mh --long minimize,help -- "$@"); then
+if ! MYOPTS=$(getopt -o mfh --long minimize,force,help -- "$@"); then
 	usage;
 	exit 1;
 fi


### PR DESCRIPTION
In the commit 375ba4e, the parameter -f / --force was added. However, this is not accepted by the script because it is missing from the getopt exam. This commit corrects the error.