### PR TITLE
fix: Removing the machine-id to meet firstboot condition

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -401,6 +401,9 @@ find "$IMAGEDIR/etc/ssh" -name "ssh_host_*_key*" -delete
 # after package raspberrypi-kernel installed, install revpi-dt-blob.dtbo as default dt-blob
 install -T "$IMAGEDIR/boot/overlays/revpi-dt-blob.dtbo" "$IMAGEDIR/boot/dt-blob.bin"
 
+# Remove machine-id to match the systemd firstboot condition on first boot of image
+rm "$IMAGEDIR/etc/machine-id"
+
 cleanup_umount
 
 fsck.vfat -a "$LOOPDEVICE"p1


### PR DESCRIPTION
The new SystemD firstboot.service was not executed because the file /etc/machine-id existed in the image. This must be deleted so that the firstboot condition is met and the firstboot scripts are executed.