### PR TITLE
Install NodeRed nodes from git tag

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -327,9 +327,10 @@ if [ "$MINIMG" != "1" ]; then
 		--output "$IMAGEDIR/$NODEREDSCRIPT"
 	chmod 755 "$IMAGEDIR/$NODEREDSCRIPT"
 	NODERED_VER="3.0.2"
+	REVPI_NODES_VERSION="1.1.0"
 	chroot "$IMAGEDIR" /usr/bin/sudo -u pi $NODEREDSCRIPT --confirm-install --confirm-pi --no-init --nodered-version="$NODERED_VER"
 	rm "$IMAGEDIR/$NODEREDSCRIPT"
-	chroot "$IMAGEDIR" /usr/bin/sudo -u pi /usr/bin/npm install --prefix /home/pi/.node-red node-red-contrib-revpi-nodes
+	chroot "$IMAGEDIR" /usr/bin/sudo -u pi /usr/bin/npm install --prefix /home/pi/.node-red "https://github.com/RevolutionPi/node-red-contrib-revpi-nodes/archive/refs/tags/${REVPI_NODES_VERSION}.tar.gz"
 
 	# remove fake procfs after NodeRed setup
 	for procfile in meminfo cpuinfo; do


### PR DESCRIPTION
The RevPi Nodes only work with a specific version of the backend server. This can lead to incompatible setups, when a new version is published to npm and we do not update our backend server too.

Fix this, until there is a better solution, by installing the RevPi Nodes from our git repository and use a specific tag.