### PR TITLE
Add fallback configuration for NetworkManager

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -390,6 +390,12 @@ cat <<EOL >$IMAGEDIR/etc/NetworkManager/conf.d/99-unmanaged-devices.conf
 unmanaged-devices=interface-name:pileft;interface-name:piright
 EOL
 
+# Use fallback to dhcp if no connection is configured
+install -o root -m 0600 "$BAKERYDIR/templates/network-manager/fallback-dhcp.nmconnection" "$IMAGEDIR/etc/NetworkManager/system-connections"
+
+# Use fallback to link-local if dhcp fails
+install -o root -m 0600 "$BAKERYDIR/templates/network-manager/fallback-link-local.nmconnection" "$IMAGEDIR/etc/NetworkManager/system-connections"
+
 # remove package lists, they will be outdated within days
 rm "$IMAGEDIR/var/lib/apt/lists/"*Packages
 

--- a/customize_image.sh
+++ b/customize_image.sh
@@ -385,10 +385,7 @@ fi
 chroot "$IMAGEDIR" raspi-config nonint do_netconf 2
 
 # Don't manage pileft / piright with NetworkManager
-cat <<EOL >$IMAGEDIR/etc/NetworkManager/conf.d/99-unmanaged-devices.conf
-[keyfile]
-unmanaged-devices=interface-name:pileft;interface-name:piright
-EOL
+install -o root -m 0644 "$BAKERYDIR/templates/network-manager/99-unmanaged-devices.conf" "$IMAGEDIR/etc/NetworkManager/conf.d/99-unmanaged-devices.conf"
 
 # Use fallback to dhcp if no connection is configured
 install -o root -m 0600 "$BAKERYDIR/templates/network-manager/fallback-dhcp.nmconnection" "$IMAGEDIR/etc/NetworkManager/system-connections"

--- a/templates/network-manager/99-unmanaged-devices.conf
+++ b/templates/network-manager/99-unmanaged-devices.conf
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices=interface-name:pileft;interface-name:piright

--- a/templates/network-manager/fallback-dhcp.nmconnection
+++ b/templates/network-manager/fallback-dhcp.nmconnection
@@ -1,0 +1,12 @@
+[connection]
+id=DHCP on unbound interfaces
+uuid=d1ae9f0b-c8a7-42aa-a238-8f1e9668f5ef
+type=ethernet
+autoconnect-priority=-98
+permissions=
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto

--- a/templates/network-manager/fallback-link-local.nmconnection
+++ b/templates/network-manager/fallback-link-local.nmconnection
@@ -1,0 +1,12 @@
+[connection]
+id==Link-local (fallback)
+uuid=a9883125-de1f-4d75-a049-124ee2adcff4
+type=ethernet
+autoconnect-priority=-99
+permissions=
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=link-local


### PR DESCRIPTION
NetworkManager behaves a bit different than dhcpcd and tries to restart
the network interface every time it fails to aquire an IP address via
DHCP (only active if no configuration has been done). Also
NetworkManager does not configure an IPv4 link local address as
fallback. In order to restore the old behaviour we need to add two
connection files:

fallback-dhcp.nmconnection: Enable DHCP fallback with low prio (-98)
fallback-link-local.nmconnection: Enable fallback to link local (v4 and
v6) with a slightly lower prio than DHCP (-99)

These two files will ensure that the user can configure a static IP or
whatever and our default config wont interfer with this.