### PR TITLE
Change modbus package names in min-debs-to-download

### DIFF
--- a/min-debs-to-download
+++ b/min-debs-to-download
@@ -6,8 +6,8 @@ revpi-webstatus
 pictory
 piserial
 pitest
-pimodbus-master
-pimodbus-slave
+revpi-modbus-client
+revpi-modbus-server
 can-utils
 python3-can
 libsocketcan-dev


### PR DESCRIPTION
Our modbus packages was renamed from pimodbus-master to revpi-modbus-client and pimodbus-slave to revpi-modbus-server. The old names only exist as transitional packages.