### PR TITLE
NetworkManager: Fix connection name for LL

### DIFF
--- a/templates/network-manager/fallback-link-local.nmconnection
+++ b/templates/network-manager/fallback-link-local.nmconnection
@@ -1,5 +1,5 @@
 [connection]
-id==Link-local (fallback)
+id=Link-local (fallback)
 uuid=a9883125-de1f-4d75-a049-124ee2adcff4
 type=ethernet
 autoconnect-priority=-99


### PR DESCRIPTION
fixes c39df4c06635f357b0bf70f1066dbdcc94e9a04f

Fix name of NetworkManagers link local template by removing trailing '='. One should be enough :-)