### PR TITLE
feat: We now support node-red-contrib-revpi-nodes as debian package

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -327,10 +327,8 @@ if [ "$MINIMG" != "1" ]; then
 		--output "$IMAGEDIR/$NODEREDSCRIPT"
 	chmod 755 "$IMAGEDIR/$NODEREDSCRIPT"
 	NODERED_VER="3.0.2"
-	REVPI_NODES_VERSION="1.1.0"
 	chroot "$IMAGEDIR" /usr/bin/sudo -u pi $NODEREDSCRIPT --confirm-install --confirm-pi --no-init --nodered-version="$NODERED_VER"
 	rm "$IMAGEDIR/$NODEREDSCRIPT"
-	chroot "$IMAGEDIR" /usr/bin/sudo -u pi /usr/bin/npm install --prefix /home/pi/.node-red "https://github.com/RevolutionPi/node-red-contrib-revpi-nodes/archive/refs/tags/${REVPI_NODES_VERSION}.tar.gz"
 
 	# remove fake procfs after NodeRed setup
 	for procfile in meminfo cpuinfo; do

--- a/debs-to-download
+++ b/debs-to-download
@@ -1,3 +1,4 @@
 revpicommander
 noderedrevpinodes-server
+node-red-contrib-revpi-nodes
 epiphany-browser


### PR DESCRIPTION
The installation of the nodes now takes place via our own debian package. This allows us to deliver and update the appropriate nodes in the appropriate version to the noderedrevpinodes server.