### PR TITLE
fix: Add revpi-webstatus-redirect package to min-debs-to-download

### DIFF
--- a/min-debs-to-download
+++ b/min-debs-to-download
@@ -2,6 +2,7 @@ raspberrypi-kernel
 revpi-firmware
 revpi-repo
 revpi-tools
+revpi-webstatus-redirect
 revpi-webstatus
 pictory
 piserial


### PR DESCRIPTION
The revpi-webstatus-redirect package redirects ports 80 and 443 to the respective webstatus ports via an apache2 configuration. The package is explicitly specified in addition to the revpi-webstatus, as it can also be removed by the user and Debian should not display the message "revpi-webstatus can be removed because it was installed as a dependency."