### PR TITLE
Free more space on CM3 4 GB

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -292,7 +292,13 @@ chroot "$IMAGEDIR" apt-get -y install revpi-wallpaper
 chroot "$IMAGEDIR" apt-mark hold raspi-copies-and-fills
 chroot "$IMAGEDIR" apt-get -y upgrade
 chroot "$IMAGEDIR" apt-mark unhold raspi-copies-and-fills
-chroot "$IMAGEDIR" apt-get clean
+
+# clean up image and free as much as possible space
+rm -rf "$IMAGEDIR"/var/cache/apt/archives/*.deb
+rm -rf "$IMAGEDIR"/var/cache/apt/*.bin
+rm -rf "$IMAGEDIR"/var/lib/apt/lists/*
+rm -rf "$IMAGEDIR"/tmp/*
+rm -rf "$IMAGEDIR"/var/tmp/*
 
 if [ -e "$IMAGEDIR/etc/init.d/apache2" ] ; then
 	# annoyingly, the postinstall script starts apache2 on fresh installs

--- a/debs-to-remove
+++ b/debs-to-remove
@@ -64,6 +64,10 @@ lxde
 # work fine without them
 desktop-base
 gtk2-engines
+gnome-icon-theme
 
 # Collides with the RevPi's hardware RTC
 fake-hwclock
+
+# Text to speach engines
+pocketsphinx-en-us

--- a/debs-to-remove
+++ b/debs-to-remove
@@ -39,11 +39,12 @@ debian-reference-common
 # Remove duplicate boost libraries, keep only libboost-iostreams1.67.0
 libboost-iostreams1.58.0
 
-# Remove duplicate gcc base files, keep only gcc-6-base
+# Remove duplicate gcc base files, keep only gcc-9-base and gcc-10-base
 gcc-4.9-base
 gcc-5-base
 gcc-6-base
 gcc-7-base
+gcc-8-base
 
 # Remove header files not required by any other package
 libfreetype6-dev


### PR DESCRIPTION
This PR extends the package cleanup list and also ensures that /var/cache/apt/pkgcache.bin is removed. In total this will free about 150 - 200 MB of space.