### PR TITLE
feat: Add reverse proxy package for Node-RED [REVPI-3227]

### DIFF
--- a/debs-to-download
+++ b/debs-to-download
@@ -2,3 +2,6 @@ revpicommander
 noderedrevpinodes-server
 node-red-contrib-revpi-nodes
 epiphany-browser
+# required for webstatus to reach a TLS secured Node-RED on port 41880
+# https://github.com/RevolutionPi/webstatus/commit/70b041d6d58044748f908dcecae81e2cac285e2d
+revpi-nodered-proxy-apache


### PR DESCRIPTION
In order for webstatus to reach Node-RED it also needs to be TLS encrypted. The TLS encryption is achieved in [0], and webstatus can reach this TLS encrypted version since [1].

For this to work, the `revpi-nodered-proxy-apache` package[2] needs to be installed, which installs the reverse proxy in apache that is needed for Node-RED.

[0]: https://github.com/RevolutionPi/revpi-nodered/commit/941c23d060c39fec84381c7fed4d542d171e4672
[1]: https://github.com/RevolutionPi/webstatus/commit/70b041d6d58044748f908dcecae81e2cac285e2d
[2]: https://github.com/RevolutionPi/revpi-nodered/tree/raspios/bullseye

This should only be merged once https://github.com/RevolutionPi/webstatus/pull/77 and https://github.com/RevolutionPi/revpi-nodered/pull/3 have been merged.