### PR TITLE
Revert "Enable kms-v3d as default"

### DIFF
--- a/templates/config.txt
+++ b/templates/config.txt
@@ -57,8 +57,8 @@ hdmi_drive=2
 dtparam=audio=on
 
 # Enable DRM VC4 V3D driver
-dtoverlay=vc4-kms-v3d
-max_framebuffers=2
+#dtoverlay=vc4-kms-v3d
+#max_framebuffers=2
 
 [pi4]
 [cm4s]


### PR DESCRIPTION
This reverts commit e9d4274039df69a66b95c9bdc54e5e78e1c5db68.

Loading an overlay in the config.txt is a bad idea. We can not package the confitg.txt. This will lead to configuration fragmentation. We should handle these changes in our dt overlays.

As we don't have any device with more then one HDMI, there is no need to set max_framebuffers=2.

https://www.raspberrypi.com/documentation/computers/config_txt.html#max_framebuffers