### PR TITLE
DHCP on eth1

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -387,6 +387,7 @@ install -o root -m 0644 "$BAKERYDIR/templates/network-manager/99-revpi.conf" "$I
 
 # Use fallback to dhcp if no connection is configured
 install -o root -m 0600 "$BAKERYDIR/templates/network-manager/dhcp-eth0.nmconnection" "$IMAGEDIR/etc/NetworkManager/system-connections"
+install -o root -m 0600 "$BAKERYDIR/templates/network-manager/dhcp-eth1.nmconnection" "$IMAGEDIR/etc/NetworkManager/system-connections"
 
 # Use fallback to link-local if dhcp fails
 install -o root -m 0600 "$BAKERYDIR/templates/network-manager/fallback-link-local-eth0.nmconnection" "$IMAGEDIR/etc/NetworkManager/system-connections"

--- a/templates/network-manager/dhcp-eth1.nmconnection
+++ b/templates/network-manager/dhcp-eth1.nmconnection
@@ -1,0 +1,17 @@
+[connection]
+id=DHCP eth1
+uuid=4e764ae2-0a96-11ee-b8b2-97bdf6db4268
+type=ethernet
+interface-name=eth1
+autoconnect=yes
+autoconnect-priority=0
+autoconnect-retries=2
+
+[ipv4]
+method=auto
+may-fail=no
+dhcp-timeout=15
+
+[ipv6]
+method=auto
+may-fail=yes


### PR DESCRIPTION
Restore the same behaviour for network interface configuration as it was with older images and configure interface eth1 with DHCP. This is also kinda required for our EOL tests (otherwise we would need additional checks for BE images)