### PR TITLE
Blockdev image size calculation

### DIFF
--- a/install_debs_into_image.sh
+++ b/install_debs_into_image.sh
@@ -136,7 +136,7 @@ fi
 # from ld.so:
 #   ERROR: ld.so: object '/usr/lib/arm-linux-gnueabihf/libarmmem-${PLATFORM}.so'
 #   from /etc/ld.so.preload cannot be preloaded (cannot open shared object file): ignored.
-mv "$IMAGEDIR/etc/ld.so.preload" "$IMAGEDIR/etc/ld.so.preload.bak"
+[[ -f "$IMAGEDIR/etc/ld.so.preload" ]] && mv "$IMAGEDIR/etc/ld.so.preload" "$IMAGEDIR/etc/ld.so.preload.bak"
 
 # customize settings
 echo `basename "$1"` > "$IMAGEDIR/etc/revpi/image-release"
@@ -158,7 +158,7 @@ find "$IMAGEDIR/var/log" -type f -delete
 find "$IMAGEDIR/etc/ssh" -name "ssh_host_*_key*" -delete
 
 # restore ld.so.preload
-mv "$IMAGEDIR/etc/ld.so.preload.bak" "$IMAGEDIR/etc/ld.so.preload"
+[[ -f "$IMAGEDIR/etc/ld.so.preload.bak" ]] && mv "$IMAGEDIR/etc/ld.so.preload.bak" "$IMAGEDIR/etc/ld.so.preload"
 
 cleanup_umount
 


### PR DESCRIPTION
fix: Use blockdev for image size calculation
    
The current approach (parse output of parted) which we use to calculate
the size of our source image is likely to fail on systems with
non-english locale setups.

Fix this by using blockdev (part of utils-linux) to get number of used
blocks.

Same fix used in Commit b3e8533