### PR TITLE
Fix pileft / piright on devices with IRQ-capable KS8851

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -258,9 +258,6 @@ chroot "$IMAGEDIR" dpkg-reconfigure -fnoninteractive keyboard-configuration
 chroot "$IMAGEDIR" dpkg-reconfigure -fnoninteractive tzdata
 chroot "$IMAGEDIR" dpkg-reconfigure -fnoninteractive locales
 
-# automatically bring up eth0 and eth1 again after a USB bus reset
-sed -i -e '6i# allow-hotplug eth0\n# allow-hotplug eth1\n' "$IMAGEDIR/etc/network/interfaces"
-
 # harden network configuration
 chroot "$IMAGEDIR" /usr/bin/patch /etc/sysctl.conf	\
 	< "$BAKERYDIR/templates/sysctl.conf.patch"

--- a/customize_image.sh
+++ b/customize_image.sh
@@ -262,6 +262,15 @@ chroot "$IMAGEDIR" dpkg-reconfigure -fnoninteractive locales
 chroot "$IMAGEDIR" /usr/bin/patch /etc/sysctl.conf	\
 	< "$BAKERYDIR/templates/sysctl.conf.patch"
 
+# ensure that pileft and piright are enabled, even if NetworkManager ignores them for configuration
+cat <<EOX >"$IMAGEDIR/etc/network/interfaces.d/revpi.conf"
+auto pileft
+iface pileft inet manual
+
+auto piright
+iface piright inet manual
+EOX
+
 # display IP address at login prompt
 sed -i -e '1s/$/ \\4 \\6/' "$IMAGEDIR/etc/issue"
 


### PR DESCRIPTION
Currently the gateway communication does not work on all devices. Older devices without IRQ attached (eg. Core 3+ or Core S) to the KS8851 ethernet controller will bring up the pileft / piright device during pi(left|right)-quirks.service:

https://github.com/RevolutionPi/revpi-tools/blob/master/tools/pibridge-shutdown#L24

On devices with attached IRQ (eg. Connect or Core S R01) the script will exit before the interface is initially brought up (which is fine):

https://github.com/RevolutionPi/revpi-tools/blob/master/tools/pibridge-shutdown#L20

Fix this by explicitly bring up the pileft and piright interfaces during boot with ifupdown.
