### PR TITLE
Keep the kernel's default cpu governor part 2

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -348,6 +348,7 @@ fi
 
 # Disable cpufrequtils to keep the default cpu governor
 chroot "$IMAGEDIR" systemctl disable cpufrequtils.service
+chroot "$IMAGEDIR" systemctl disable raspi-config.service
 
 # Since Raspberry Pi OS Bullseye the default user pi will only be used for the first
 # boot and then replaced by a username which has to be defined in the first boot wizard.


### PR DESCRIPTION
The cpu governer is set to performance in our kernel configurations. Just make sure raspi-config is not setting it to ondemand again.

"raspi-config.service - LSB: Switch to ondemand cpu governor (unless shift key is pressed)"

See https://github.com/RevolutionPi/revpi-tools/blob/master/revpi-config/revpi-config#L98C1-L98C27