### PR TITLE
fix: Removes Raspberry Pi wizards to change `pi` username

### DIFF
--- a/debs-to-remove
+++ b/debs-to-remove
@@ -72,3 +72,7 @@ fake-hwclock
 
 # Text to speach engines
 pocketsphinx-en-us
+
+# Remove rename wizards for user pi
+userconf-pi
+piwiz


### PR DESCRIPTION
This commit removes the packages `piwiz` and `userconf-pi` of the Raspberry Pi, which allow a renaming of the user name `pi`. Our system is currently dependent on the user `pi` and this assistant leads to an error that prevents logging in to the Revolution Pi.