### PR TITLE
fix: Avoid writing logrotate configuration

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -193,23 +193,6 @@ if [ -e "$IMAGEDIR/boot/kernel8.img" ]; then
 	sed -i '/^\[all\]/a dtoverlay=dwc2,dr_mode=host' "$IMAGEDIR/boot/config.txt"
 fi
 
-# limit disk space occupied by logs
-ln -s ../cron.daily/logrotate "$IMAGEDIR/etc/cron.hourly"
-sed -r -i -e 's/delaycompress/#delaycompress/' \
-	  -e 's/sharedscripts/#sharedscripts/' \
-	  "$IMAGEDIR/etc/logrotate.d/rsyslog"
-sed -r -i -e 's/#compress/compress/' -e '2i \
-\
-# limit size of each log file\
-maxsize 10M\
-\
-# compress harder\
-compresscmd /usr/bin/nice\
-compressoptions /usr/bin/xz\
-compressext .xz\
-uncompresscmd /usr/bin/unxz\
-' "$IMAGEDIR"/etc/logrotate.conf
-
 # bootstrap apt source, will be overwritten by revpi-repo package
 cp "$BAKERYDIR/templates/revpi.gpg" "$IMAGEDIR/etc/apt/trusted.gpg.d"
 cp "$BAKERYDIR/templates/revpi.list" "$IMAGEDIR/etc/apt/sources.list.d"

--- a/min-debs-to-download
+++ b/min-debs-to-download
@@ -2,6 +2,7 @@ raspberrypi-kernel
 revpi-firmware
 revpi-repo
 revpi-tools
+revpi-base-files
 revpi-webstatus-redirect
 revpi-webstatus
 pictory


### PR DESCRIPTION
The configuration for logrotate should be done in separate configuration files in `/etc/logrotate.d/` and should ideally live in a separate package so that the configuration can be updated for existing systems if necessary or removed by the user if it is not needed.

Instead, the configuration now lives in the `revpi-base-files` package.