### PR TITLE
feat!: Don't add i2c-dev to /etc/modules

### DIFF
--- a/customize_image.sh
+++ b/customize_image.sh
@@ -238,9 +238,6 @@ echo UTC > "$IMAGEDIR/etc/timezone"
 rm "$IMAGEDIR/etc/localtime"
 echo RevPi > "$IMAGEDIR/etc/hostname"
 sed -i -e 's/raspberrypi/RevPi/g' "$IMAGEDIR/etc/hosts"
-if ! grep -qE '^i2c-dev$' "$IMAGEDIR/etc/modules" ; then
-	echo i2c-dev >> "$IMAGEDIR/etc/modules"
-fi
 echo piControl >> "$IMAGEDIR/etc/modules"
 sed -i -r -e 's/^(XKBMODEL).*/\1="pc104"/' \
 	-e 's/^(XKBLAYOUT).*/\1="us"/' \


### PR DESCRIPTION
PiSerial need i2c-dev to read the ATECC508A crypto chip. Patching /etc/modules is not the best way. And the imagebakery is the wrong place.
Let the piserial package add this to /etc/modules-load.d/ and remove this hack from the imagebakery.

This should only be merged after https://gitlab.com/revolutionpi/piserial/-/merge_requests/70 is merged.